### PR TITLE
Store stream in packet receive path instead of asynchronously to fix https://github.com/cbeuw/Cloak/issues/74

### DIFF
--- a/internal/multiplex/session.go
+++ b/internal/multiplex/session.go
@@ -124,7 +124,6 @@ func (sesh *Session) Accept() (net.Conn, error) {
 	if stream == nil {
 		return nil, ErrBrokenSession
 	}
-	sesh.streams.Store(stream.id, stream)
 	log.Tracef("stream %v of session %v accepted", stream.id, sesh.id)
 	return stream, nil
 }
@@ -200,6 +199,7 @@ func (sesh *Session) recvDataFromRemote(data []byte) error {
 			connId, _, _ := sesh.sb.pickRandConn()
 			// we ignore the error here. If the switchboard is broken, it will be reflected upon stream.Write
 			stream := makeStream(sesh, frame.StreamID, connId)
+			sesh.streams.Store(stream.id, stream)
 			sesh.acceptCh <- stream
 			return stream.writeFrame(*frame)
 		}


### PR DESCRIPTION
This is a simple change that fixes bug https://github.com/cbeuw/Cloak/issues/74

The cause of the bug was a race condition between storing the created stream in the session and reading the next packet for this stream on the server.