### PR TITLE
Accept log level flag even when started in shadowsocks mode.

### DIFF
--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -241,6 +241,15 @@ func main() {
 		remoteHost = os.Getenv("SS_REMOTE_HOST")
 		remotePort = os.Getenv("SS_REMOTE_PORT")
 		config = os.Getenv("SS_PLUGIN_OPTIONS")
+
+		verbosity := flag.String("verbosity", "debug", "verbosity level")
+		flag.Parse()
+
+		lvl, err := log.ParseLevel(*verbosity)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.SetLevel(lvl)
 	} else {
 		flag.StringVar(&localHost, "i", "127.0.0.1", "localHost: Cloak listens to proxy clients on this ip")
 		flag.StringVar(&localPort, "l", "1984", "localPort: Cloak listens to proxy clients on this port")


### PR DESCRIPTION
This allows passing a log level flag using "plugin arguments" feature of shadowsocks when cloak is running in shadowsocks mode which is very helpful to enable verbose debugging when troubleshooting issues, instead of being forced to run it standalone.