### PR TITLE
Accept and ignore 2 parameters passed by shadowsocks-android in shadowsocks plugin mode.

### DIFF
--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -30,6 +30,8 @@ func main() {
 	var udp bool
 	var config string
 	var b64AdminUID string
+	var vpnMode bool
+	var tcpFastOpen bool
 
 	log_init()
 
@@ -38,6 +40,8 @@ func main() {
 	verbosity := flag.String("verbosity", "info", "verbosity level")
 	if ssPluginMode {
 		config = os.Getenv("SS_PLUGIN_OPTIONS")
+		flag.BoolVar(&vpnMode, "V", false, "ignored.")
+		flag.BoolVar(&tcpFastOpen, "fast-open", false, "ignored.")
 		flag.Parse() // for verbosity only
 	} else {
 		flag.StringVar(&localHost, "i", "127.0.0.1", "localHost: Cloak listens to proxy clients on this ip")


### PR DESCRIPTION
Since my previous pull request that allowed parameter parsing in shadowsocks mode, compiling latest Cloak-Android gave a non-working binary when used with shadowsocks-android.

In case of VPN mode and fast-open, shadowsocks-android intentionally passes up to 2 extra parameters (-V and --fast-open) to the SIP003 plugin. Since golang flag does not ignore unknown flags, it causes the plugin to start and fail immediately.

This pull request lets cloak accept and ignore those 2 parameters safely in shadowsocks mode.