### PR TITLE
Support session per connection mode (like GoQuiet) when NumConn = 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Example:
 
 `ServerName` is the domain you want to make your ISP or firewall think you are visiting.
 
-`NumConn` is the amount of underlying TCP connections you want to use. The default of 4 should be appropriate for most people. Setting it too high will hinder the performance. 
+`NumConn` is the amount of underlying TCP connections you want to use. The default of 4 should be appropriate for most people. Setting it too high will hinder the performance. Setting it to 0 will disable connection multiplexing and each TCP connection will spawn a separate short lived session that will be closed after it is terminated. This makes it behave like GoQuiet. This maybe useful for people with unstable connections.
 
 `BrowserSig` is the browser you want to **appear** to be using. It's not relevant to the browser you are actually using. Currently, `chrome` and `firefox` are supported.
 

--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -169,18 +169,20 @@ func main() {
 		}
 	}
 
+	useSessionPerConnection := remoteConfig.NumConn == 0
+
 	if authInfo.Unordered {
 		acceptor := func() (*net.UDPConn, error) {
 			udpAddr, _ := net.ResolveUDPAddr("udp", localConfig.LocalAddr)
 			return net.ListenUDP("udp", udpAddr)
 		}
 
-		client.RouteUDP(acceptor, localConfig.Timeout, seshMaker)
+		client.RouteUDP(acceptor, localConfig.Timeout, seshMaker, useSessionPerConnection)
 	} else {
 		listener, err := net.Listen("tcp", localConfig.LocalAddr)
 		if err != nil {
 			log.Fatal(err)
 		}
-		client.RouteTCP(listener, localConfig.Timeout, seshMaker)
+		client.RouteTCP(listener, localConfig.Timeout, seshMaker, useSessionPerConnection)
 	}
 }

--- a/internal/client/connector.go
+++ b/internal/client/connector.go
@@ -25,10 +25,16 @@ func MakeSession(connConfig RemoteConnConfig, authInfo AuthInfo, dialer common.D
 		authInfo.SessionId = 0
 	}
 
-	connsCh := make(chan net.Conn, connConfig.NumConn)
+	numConn := connConfig.NumConn
+	if numConn <= 0 {
+		log.Infof("Using session per connection (no multiplexing)")
+		numConn = 1
+	}
+
+	connsCh := make(chan net.Conn, numConn)
 	var _sessionKey atomic.Value
 	var wg sync.WaitGroup
-	for i := 0; i < connConfig.NumConn; i++ {
+	for i := 0; i < numConn; i++ {
 		wg.Add(1)
 		go func() {
 		makeconn:
@@ -70,7 +76,7 @@ func MakeSession(connConfig RemoteConnConfig, authInfo AuthInfo, dialer common.D
 	}
 	sesh := mux.MakeSession(authInfo.SessionId, seshConfig)
 
-	for i := 0; i < connConfig.NumConn; i++ {
+	for i := 0; i < numConn; i++ {
 		conn := <-connsCh
 		sesh.AddConnection(conn)
 	}

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -172,8 +172,8 @@ func (raw *RawConfig) SplitConfigs(worldState common.WorldState) (local LocalCon
 		return nullErr("RemotePort")
 	}
 	remote.RemoteAddr = net.JoinHostPort(raw.RemoteHost, raw.RemotePort)
-	if raw.NumConn == 0 {
-		return nullErr("NumConn")
+	if raw.NumConn <= 0 {
+		raw.NumConn = 0
 	}
 	remote.NumConn = raw.NumConn
 

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -139,6 +139,7 @@ func establishSession(lcc client.LocalConnConfig, rcc client.RemoteConnConfig, a
 		return client.MakeSession(rcc, ai, ckClientDialer, false)
 	}
 
+	useSessionPerConnection := rcc.NumConn == 0
 	var proxyToCkClientD common.Dialer
 	if ai.Unordered {
 		addrCh := make(chan *net.UDPAddr, 1)
@@ -151,12 +152,12 @@ func establishSession(lcc client.LocalConnConfig, rcc client.RemoteConnConfig, a
 			addrCh <- conn.LocalAddr().(*net.UDPAddr)
 			return conn, err
 		}
-		go client.RouteUDP(acceptor, lcc.Timeout, clientSeshMaker)
+		go client.RouteUDP(acceptor, lcc.Timeout, clientSeshMaker, useSessionPerConnection)
 		proxyToCkClientD = mDialer
 	} else {
 		var proxyToCkClientL *connutil.PipeListener
 		proxyToCkClientD, proxyToCkClientL = connutil.DialerListener(10 * 1024)
-		go client.RouteTCP(proxyToCkClientL, lcc.Timeout, clientSeshMaker)
+		go client.RouteTCP(proxyToCkClientL, lcc.Timeout, clientSeshMaker, useSessionPerConnection)
 	}
 
 	// set up server


### PR DESCRIPTION
This adds a "goquiet" mode to Cloak where every TCP connection is handled in a separate session. This maybe useful for people on unstable connections where the DPI/GFW cuts long time idle HTTPS connections (by dropping packets without tcp reset) and Cloak takes a very long time or doesn't recover until it's restarted. To use this mode, just set NumConn=0 in the config.