### PR TITLE
Added port to RedirAddr

### DIFF
--- a/example_config/ckserver.json
+++ b/example_config/ckserver.json
@@ -20,7 +20,7 @@
   "BypassUID": [
     "1rmq6Ag1jZJCImLBIL5wzQ=="
   ],
-  "RedirAddr": "204.79.197.200",
+  "RedirAddr": "204.79.197.200:443",
   "PrivateKey": "EN5aPEpNBO+vw+BtFQY2OnK9bQU7rvEj5qmnmgwEtUc=",
   "AdminUID": "5nneblJy6lniPJfr81LuYQ==",
   "DatabasePath": "userinfo.db",


### PR DESCRIPTION
Hello
It [looks like](https://github.com/HirbodBehnam/Shadowsocks-Cloak-Installer/issues/32#issuecomment-679173946) that the RedirAddr must contain a port.
I've just updated the example config file.