### PR TITLE
Respect user choice of ProxyMethod in shadowsocks plugin mode.

### DIFF
--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -85,7 +85,9 @@ func main() {
 	}
 
 	if ssPluginMode {
-		rawConfig.ProxyMethod = "shadowsocks"
+		if rawConfig.ProxyMethod == "" {
+			rawConfig.ProxyMethod = "shadowsocks"
+		}
 		// json takes precedence over environment variables
 		// i.e. if json field isn't empty, use that
 		if rawConfig.RemoteHost == "" {


### PR DESCRIPTION
There's no reason to force the ProxyMethod to shadowsocks and overwrite the user's wishes (in the config string).