### PR TITLE
Add CdnHttpHost config setting with documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,11 @@ techniques).**
 `ServerName` is the domain you want to make your ISP or firewall _think_ you are visiting. Ideally it should
 match `RedirAddr` in the server's configuration, a major site the censor allows, but it doesn't have to.
 
-`CdnHttpHost` is a setting that only has an effect when `Transport` is set to `CDN`. In `CDN` mode, Cloak makes a full 
-SSL handshake and then initiates an HTTP websocket request. This setting allows overriding the HTTP `Host` header 
-address value in the inner HTTP request. Note: This needs to be only a domain, the port is taken from the remote port 
-that Cloak connects to. This can be useful for some cases such as shadowsocks-android which don't pass the remote 
-address domain name but rather its resolved IP address. This override also allows you to try to use domain fronting by 
-specifying a different Host header than the outer domain passed in the SSL handshake's SNI field. If this field is not 
-set, the passed remote address will be used.
+`CDNOriginHost` is the domain name of the _origin_ server (i.e. the server running Cloak) under `CDN` mode. This only
+has effect when `Transport` is set to `CDN`. If unset, it will default to the remote hostname supplied via the
+commandline argument (in standalone mode), or by Shadowsocks (in plugin mode). After a TLS session is established with
+the CDN server, this domain name will be used in the HTTP request to ask the CDN server to establish a WebSocket
+connection with this host.
 
 `NumConn` is the amount of underlying TCP connections you want to use. The default of 4 should be appropriate for most
 people. Setting it too high will hinder the performance. Setting it to 0 will disable connection multiplexing and each

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ techniques).**
 `ServerName` is the domain you want to make your ISP or firewall _think_ you are visiting. Ideally it should
 match `RedirAddr` in the server's configuration, a major site the censor allows, but it doesn't have to.
 
+`CdnHttpHost` is a setting that only has an effect when `Transport` is set to `CDN`. In `CDN` mode, Cloak makes a full 
+SSL handshake and then initiates an HTTP websocket request. This setting allows overriding the HTTP `Host` header 
+address value in the inner HTTP request. Note: This needs to be only a domain, the port is taken from the remote port 
+that Cloak connects to. This can be useful for some cases such as shadowsocks-android which don't pass the remote 
+address domain name but rather its resolved IP address. This override also allows you to try to use domain fronting by 
+specifying a different Host header than the outer domain passed in the SSL handshake's SNI field. If this field is not 
+set, the passed remote address will be used.
+
 `NumConn` is the amount of underlying TCP connections you want to use. The default of 4 should be appropriate for most
 people. Setting it too high will hinder the performance. Setting it to 0 will disable connection multiplexing and each
 TCP connection will spawn a separate short-lived session that will be closed after it is terminated. This makes it

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -35,7 +35,7 @@ type RawConfig struct {
 	UDP           bool   // nullable
 	BrowserSig    string // nullable
 	Transport     string // nullable
-	CdnHttpHost   string // nullable
+	CDNOriginHost string // nullable
 	StreamTimeout int    // nullable
 	KeepAlive     int    // nullable
 }
@@ -187,14 +187,16 @@ func (raw *RawConfig) ProcessRawConfig(worldState common.WorldState) (local Loca
 		remote.Singleplex = false
 	}
 
-	if raw.CdnHttpHost == "" {
-		raw.CdnHttpHost = raw.RemoteHost
-	}
-
 	// Transport and (if TLS mode), browser
 	switch strings.ToLower(raw.Transport) {
 	case "cdn":
-		cdnDomainPort := net.JoinHostPort(raw.CdnHttpHost, raw.RemotePort)
+		var cdnDomainPort string
+		if raw.CDNOriginHost == "" {
+			cdnDomainPort = net.JoinHostPort(raw.RemoteHost, raw.RemotePort)
+		} else {
+			cdnDomainPort = net.JoinHostPort(raw.CDNOriginHost, raw.RemotePort)
+		}
+
 		remote.TransportMaker = func() Transport {
 			return &WSOverTLS{
 				cdnDomainPort: cdnDomainPort,

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -35,6 +35,7 @@ type RawConfig struct {
 	UDP           bool   // nullable
 	BrowserSig    string // nullable
 	Transport     string // nullable
+	CdnHttpHost   string // nullable
 	StreamTimeout int    // nullable
 	KeepAlive     int    // nullable
 }
@@ -186,12 +187,17 @@ func (raw *RawConfig) ProcessRawConfig(worldState common.WorldState) (local Loca
 		remote.Singleplex = false
 	}
 
+	if raw.CdnHttpHost == "" {
+		raw.CdnHttpHost = raw.RemoteHost
+	}
+
 	// Transport and (if TLS mode), browser
 	switch strings.ToLower(raw.Transport) {
 	case "cdn":
+		cdnDomainPort := net.JoinHostPort(raw.CdnHttpHost, raw.RemotePort)
 		remote.TransportMaker = func() Transport {
 			return &WSOverTLS{
-				cdnDomainPort: remote.RemoteAddr,
+				cdnDomainPort: cdnDomainPort,
 			}
 		}
 	case "direct":


### PR DESCRIPTION
This solved CDN mode not working in shadowsocks-android. Another pull request will be opened on Cloak-android to add the new config setting to the config screen.