### PR TITLE
Fix critical bugs in session opening for TCP and UDP in case of Singleplex mode.

### DIFF
--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -184,12 +184,12 @@ func main() {
 			return net.ListenUDP("udp", udpAddr)
 		}
 
-		client.RouteUDP(acceptor, localConfig.Timeout, seshMaker)
+		client.RouteUDP(acceptor, localConfig.Timeout, remoteConfig.Singleplex, seshMaker)
 	} else {
 		listener, err := net.Listen("tcp", localConfig.LocalAddr)
 		if err != nil {
 			log.Fatal(err)
 		}
-		client.RouteTCP(listener, localConfig.Timeout, seshMaker)
+		client.RouteTCP(listener, localConfig.Timeout, remoteConfig.Singleplex, seshMaker)
 	}
 }

--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -169,6 +169,7 @@ func main() {
 		}
 		log.Infof("Listening on %v %v for %v client", network, localConfig.LocalAddr, authInfo.ProxyMethod)
 		seshMaker = func() *mux.Session {
+			authInfo := authInfo // copy the struct because we are overwriting SessionId
 			// sessionID is usergenerated. There shouldn't be a security concern because the scope of
 			// sessionID is limited to its UID.
 			quad := make([]byte, 4)

--- a/internal/client/piper.go
+++ b/internal/client/piper.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RouteUDP(bindFunc func() (*net.UDPConn, error), streamTimeout time.Duration, singleplex bool, newSeshFunc func() *mux.Session) {
-	var multiplexSession *mux.Session
+	var sesh *mux.Session
 	localConn, err := bindFunc()
 	if err != nil {
 		log.Fatal(err)
@@ -27,25 +27,19 @@ func RouteUDP(bindFunc func() (*net.UDPConn, error), streamTimeout time.Duration
 			continue
 		}
 
-		if !singleplex && (multiplexSession == nil || multiplexSession.IsClosed()) {
-			multiplexSession = newSeshFunc()
+		if !singleplex && (sesh == nil || sesh.IsClosed()) {
+			sesh = newSeshFunc()
 		}
 
 		stream, ok := streams[addr.String()]
 		if !ok {
-			var session *mux.Session
-			if multiplexSession != nil {
-				session = multiplexSession
-			} else {
-				session = newSeshFunc()
+			if singleplex {
+				sesh = newSeshFunc()
 			}
 
-			stream, err = session.OpenStream()
+			stream, err = sesh.OpenStream()
 			if err != nil {
 				log.Errorf("Failed to open stream: %v", err)
-				if session.Singleplex {
-					session.Close()
-				}
 				continue
 			}
 
@@ -82,22 +76,19 @@ func RouteUDP(bindFunc func() (*net.UDPConn, error), streamTimeout time.Duration
 }
 
 func RouteTCP(listener net.Listener, streamTimeout time.Duration, singleplex bool, newSeshFunc func() *mux.Session) {
-	var multiplexSession *mux.Session
+	var sesh *mux.Session
 	for {
 		localConn, err := listener.Accept()
 		if err != nil {
 			log.Fatal(err)
 			continue
 		}
-		if !singleplex && (multiplexSession == nil || multiplexSession.IsClosed()) {
-			multiplexSession = newSeshFunc()
+		if !singleplex && (sesh == nil || sesh.IsClosed()) {
+			sesh = newSeshFunc()
 		}
-		go func(multiplexSession *mux.Session, newSingleplexSeshFunc func() *mux.Session, localConn net.Conn, timeout time.Duration) {
-			var session *mux.Session
-			if multiplexSession != nil {
-				session = multiplexSession
-			} else {
-				session = newSingleplexSeshFunc()
+		go func(sesh *mux.Session, localConn net.Conn, timeout time.Duration) {
+			if singleplex {
+				sesh = newSeshFunc()
 			}
 
 			data := make([]byte, 10240)
@@ -111,13 +102,10 @@ func RouteTCP(listener net.Listener, streamTimeout time.Duration, singleplex boo
 			var zeroTime time.Time
 			_ = localConn.SetReadDeadline(zeroTime)
 
-			stream, err := session.OpenStream()
+			stream, err := sesh.OpenStream()
 			if err != nil {
 				log.Errorf("Failed to open stream: %v", err)
 				localConn.Close()
-				if session.Singleplex {
-					session.Close()
-				}
 				return
 			}
 
@@ -137,6 +125,6 @@ func RouteTCP(listener net.Listener, streamTimeout time.Duration, singleplex boo
 			if _, err = common.Copy(stream, localConn); err != nil {
 				log.Tracef("copying proxy client to stream: %v", err)
 			}
-		}(multiplexSession, newSeshFunc, localConn, streamTimeout)
+		}(sesh, localConn, streamTimeout)
 	}
 }

--- a/internal/client/piper.go
+++ b/internal/client/piper.go
@@ -39,6 +39,9 @@ func RouteUDP(bindFunc func() (*net.UDPConn, error), streamTimeout time.Duration
 
 			stream, err = sesh.OpenStream()
 			if err != nil {
+				if singleplex {
+					sesh.Close()
+				}
 				log.Errorf("Failed to open stream: %v", err)
 				continue
 			}
@@ -106,6 +109,9 @@ func RouteTCP(listener net.Listener, streamTimeout time.Duration, singleplex boo
 			if err != nil {
 				log.Errorf("Failed to open stream: %v", err)
 				localConn.Close()
+				if singleplex {
+					sesh.Close()
+				}
 				return
 			}
 

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -206,12 +206,12 @@ func establishSession(lcc client.LocalConnConfig, rcc client.RemoteConnConfig, a
 			addrCh <- conn.LocalAddr().(*net.UDPAddr)
 			return conn, err
 		}
-		go client.RouteUDP(acceptor, lcc.Timeout, clientSeshMaker)
+		go client.RouteUDP(acceptor, lcc.Timeout, rcc.Singleplex, clientSeshMaker)
 		proxyToCkClientD = mDialer
 	} else {
 		var proxyToCkClientL *connutil.PipeListener
 		proxyToCkClientD, proxyToCkClientL = connutil.DialerListener(10 * 1024)
-		go client.RouteTCP(proxyToCkClientL, lcc.Timeout, clientSeshMaker)
+		go client.RouteTCP(proxyToCkClientL, lcc.Timeout, rcc.Singleplex, clientSeshMaker)
 	}
 
 	// set up server

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -185,11 +185,9 @@ func establishSession(lcc client.LocalConnConfig, rcc client.RemoteConnConfig, a
 	//									whatever connection initiator (including a proper ck-client)
 
 	netToCkServerD, ckServerListener := connutil.DialerListener(10 * 1024)
-	var sessionCreateMutex sync.Mutex
 
 	clientSeshMaker := func() *mux.Session {
-		sessionCreateMutex.Lock()
-		defer sessionCreateMutex.Unlock()
+		ai := ai
 		quad := make([]byte, 4)
 		common.RandRead(ai.WorldState.Rand, quad)
 		ai.SessionId = binary.BigEndian.Uint32(quad)

--- a/internal/test/integration_test.go
+++ b/internal/test/integration_test.go
@@ -185,7 +185,11 @@ func establishSession(lcc client.LocalConnConfig, rcc client.RemoteConnConfig, a
 	//									whatever connection initiator (including a proper ck-client)
 
 	netToCkServerD, ckServerListener := connutil.DialerListener(10 * 1024)
+	var sessionCreateMutex sync.Mutex
+
 	clientSeshMaker := func() *mux.Session {
+		sessionCreateMutex.Lock()
+		defer sessionCreateMutex.Unlock()
 		quad := make([]byte, 4)
 		common.RandRead(ai.WorldState.Rand, quad)
 		ai.SessionId = binary.BigEndian.Uint32(quad)


### PR DESCRIPTION
- In case of TCP, don't open the session in the listener accept thread. This
  causes resource exhaustion of the tcp listener backlog queue in case of internet
  connection disruption or timeout.

- In case of UDP, don't create a new session for every UDP packet.

This also fixes https://github.com/cbeuw/Cloak-android/issues/17 and corrects a lot of wrong behaviors.
@cbeuw Please check and merge, and I recommend a new release.