### PR TITLE
ServerName rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ encryption and authentication (via AEAD or similar techniques).**
 `ServerName` is the domain you want to make your ISP or firewall _think_ you are visiting. Ideally it should
 match `RedirAddr` in the server's configuration, a major site the censor allows, but it doesn't have to.
 
+`AlternativeNames` is an array used alongside `ServerName` to shuffle between different ServerNames for every new connection
+
 `CDNOriginHost` is the domain name of the _origin_ server (i.e. the server running Cloak) under `CDN` mode. This only
 has effect when `Transport` is set to `CDN`. If unset, it will default to the remote hostname supplied via the
 commandline argument (in standalone mode), or by Shadowsocks (in plugin mode). After a TLS session is established with

--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -177,7 +177,7 @@ func main() {
 			// sessionID is usergenerated. There shouldn't be a security concern because the scope of
 			// sessionID is limited to its UID.
 
-			authInfo.MockDomain = authInfo.MockDomainList[rand.Intn(len(authInfo.MockDomainList))]
+			authInfo.MockDomain = localConfig.MockDomainList[rand.Intn(len(localConfig.MockDomainList))]
 			quad := make([]byte, 4)
 			common.RandRead(authInfo.WorldState.Rand, quad)
 			authInfo.SessionId = binary.BigEndian.Uint32(quad)

--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/cbeuw/Cloak/internal/common"
+	"math/rand"
 	"net"
 	"os"
 
@@ -175,6 +176,8 @@ func main() {
 			authInfo := authInfo // copy the struct because we are overwriting SessionId
 			// sessionID is usergenerated. There shouldn't be a security concern because the scope of
 			// sessionID is limited to its UID.
+
+			authInfo.MockDomain = authInfo.MockDomainList[rand.Intn(len(authInfo.MockDomainList))]
 			quad := make([]byte, 4)
 			common.RandRead(authInfo.WorldState.Rand, quad)
 			authInfo.SessionId = binary.BigEndian.Uint32(quad)

--- a/cmd/ck-client/ck-client.go
+++ b/cmd/ck-client/ck-client.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/cbeuw/Cloak/internal/common"
-	"math/rand"
 	"net"
 	"os"
 
@@ -174,10 +173,13 @@ func main() {
 		log.Infof("Listening on %v %v for %v client", network, localConfig.LocalAddr, authInfo.ProxyMethod)
 		seshMaker = func() *mux.Session {
 			authInfo := authInfo // copy the struct because we are overwriting SessionId
+
+			randByte := make([]byte, 1)
+			common.RandRead(authInfo.WorldState.Rand, randByte)
+			authInfo.MockDomain = localConfig.MockDomainList[int(randByte[0])%len(localConfig.MockDomainList)]
+
 			// sessionID is usergenerated. There shouldn't be a security concern because the scope of
 			// sessionID is limited to its UID.
-
-			authInfo.MockDomain = localConfig.MockDomainList[rand.Intn(len(localConfig.MockDomainList))]
 			quad := make([]byte, 4)
 			common.RandRead(authInfo.WorldState.Rand, quad)
 			authInfo.SessionId = binary.BigEndian.Uint32(quad)

--- a/cmd/ck-client/protector_android.go
+++ b/cmd/ck-client/protector_android.go
@@ -1,4 +1,5 @@
 // +build android
+
 package main
 
 // Stolen from https://github.com/shadowsocks/overture/blob/shadowsocks/core/utils/utils_android.go

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -49,8 +49,9 @@ type RemoteConnConfig struct {
 }
 
 type LocalConnConfig struct {
-	LocalAddr string
-	Timeout   time.Duration
+	LocalAddr      string
+	Timeout        time.Duration
+	MockDomainList []string
 }
 
 type AuthInfo struct {
@@ -61,7 +62,6 @@ type AuthInfo struct {
 	Unordered        bool
 	ServerPubKey     crypto.PublicKey
 	MockDomain       string
-	MockDomainList   []string
 	WorldState       common.WorldState
 }
 
@@ -154,8 +154,8 @@ func (raw *RawConfig) ProcessRawConfig(worldState common.WorldState) (local Loca
 		return nullErr("ServerName")
 	}
 	auth.MockDomain = raw.ServerName
-	auth.MockDomainList = raw.AlternativeNames
-	auth.MockDomainList = append(auth.MockDomainList, auth.MockDomain)
+	local.MockDomainList = raw.AlternativeNames
+	local.MockDomainList = append(local.MockDomainList, auth.MockDomain)
 	if raw.ProxyMethod == "" {
 		return nullErr("ServerName")
 	}

--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -26,11 +26,11 @@ type RawConfig struct {
 	UID              []byte
 	PublicKey        []byte
 	NumConn          int
-	LocalHost        string // jsonOptional
-	LocalPort        string // jsonOptional
-	RemoteHost       string // jsonOptional
-	RemotePort       string // jsonOptional
-
+	LocalHost        string   // jsonOptional
+	LocalPort        string   // jsonOptional
+	RemoteHost       string   // jsonOptional
+	RemotePort       string   // jsonOptional
+	AlternativeNames []string // jsonOptional
 	// defaults set in ProcessRawConfig
 	UDP           bool   // nullable
 	BrowserSig    string // nullable
@@ -61,6 +61,7 @@ type AuthInfo struct {
 	Unordered        bool
 	ServerPubKey     crypto.PublicKey
 	MockDomain       string
+	MockDomainList   []string
 	WorldState       common.WorldState
 }
 
@@ -94,6 +95,20 @@ func ssvToJson(ssv string) (ret []byte) {
 		}
 		key := sp[0]
 		value := sp[1]
+		if strings.HasPrefix(key, "AlternativeNames") {
+			switch strings.Contains(value, ",") {
+			case true:
+				domains := strings.Split(value, ",")
+				for index, domain := range domains {
+					domains[index] = `"` + domain + `"`
+				}
+				value = strings.Join(domains, ",")
+				ret = append(ret, []byte(`"`+key+`":[`+value+`],`)...)
+			case false:
+				ret = append(ret, []byte(`"`+key+`":["`+value+`"],`)...)
+			}
+			continue
+		}
 		// JSON doesn't like quotation marks around int and bool
 		// This is extremely ugly but it's still better than writing a tokeniser
 		if elem(key, unquoted) {
@@ -139,6 +154,8 @@ func (raw *RawConfig) ProcessRawConfig(worldState common.WorldState) (local Loca
 		return nullErr("ServerName")
 	}
 	auth.MockDomain = raw.ServerName
+	auth.MockDomainList = raw.AlternativeNames
+	auth.MockDomainList = append(auth.MockDomainList, auth.MockDomain)
 	if raw.ProxyMethod == "" {
 		return nullErr("ServerName")
 	}


### PR DESCRIPTION
This PR solves #152 by adding an optional AlternativeNames slice that has domains that cloak will shuffle through after every new session 