### PR TITLE
Fix incorrect addition of empty name in MockDomainList if the config string contains AlternativeNames=;

### DIFF
--- a/internal/client/state.go
+++ b/internal/client/state.go
@@ -154,6 +154,15 @@ func (raw *RawConfig) ProcessRawConfig(worldState common.WorldState) (local Loca
 		return nullErr("ServerName")
 	}
 	auth.MockDomain = raw.ServerName
+
+	var filteredAlternativeNames []string
+	for _, alternativeName := range raw.AlternativeNames {
+		if len(alternativeName) > 0 {
+			filteredAlternativeNames = append(filteredAlternativeNames, alternativeName)
+		}
+	}
+	raw.AlternativeNames = filteredAlternativeNames
+
 	local.MockDomainList = raw.AlternativeNames
 	local.MockDomainList = append(local.MockDomainList, auth.MockDomain)
 	if raw.ProxyMethod == "" {


### PR DESCRIPTION
This bug is very visible and annoying on Android and makes Cloak unreliable (since it picks randomly between the empty name and the real ServerName).