### PR TITLE
Pad the first 5 frames to mitigate encapsulated TLS handshakes detection

### DIFF
--- a/internal/multiplex/obfs_test.go
+++ b/internal/multiplex/obfs_test.go
@@ -85,7 +85,6 @@ func TestObfuscate(t *testing.T) {
 		o := Obfuscator{
 			payloadCipher: nil,
 			sessionKey:    sessionKey,
-			maxOverhead:   salsa20NonceSize,
 		}
 		runTest(t, o)
 	})
@@ -98,7 +97,6 @@ func TestObfuscate(t *testing.T) {
 		o := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    sessionKey,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		runTest(t, o)
 	})
@@ -111,7 +109,6 @@ func TestObfuscate(t *testing.T) {
 		o := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    sessionKey,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		runTest(t, o)
 	})
@@ -122,7 +119,6 @@ func TestObfuscate(t *testing.T) {
 		o := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    sessionKey,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		runTest(t, o)
 	})
@@ -150,7 +146,6 @@ func BenchmarkObfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 
 		b.SetBytes(int64(len(testFrame.Payload)))
@@ -166,7 +161,6 @@ func BenchmarkObfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		b.SetBytes(int64(len(testFrame.Payload)))
 		b.ResetTimer()
@@ -178,7 +172,6 @@ func BenchmarkObfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: nil,
 			sessionKey:    key,
-			maxOverhead:   salsa20NonceSize,
 		}
 		b.SetBytes(int64(len(testFrame.Payload)))
 		b.ResetTimer()
@@ -192,7 +185,6 @@ func BenchmarkObfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		b.SetBytes(int64(len(testFrame.Payload)))
 		b.ResetTimer()
@@ -222,7 +214,6 @@ func BenchmarkDeobfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 
 		n, _ := obfuscator.obfuscate(testFrame, obfsBuf, 0)
@@ -241,7 +232,6 @@ func BenchmarkDeobfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 		n, _ := obfuscator.obfuscate(testFrame, obfsBuf, 0)
 
@@ -256,7 +246,6 @@ func BenchmarkDeobfs(b *testing.B) {
 		obfuscator := Obfuscator{
 			payloadCipher: nil,
 			sessionKey:    key,
-			maxOverhead:   salsa20NonceSize,
 		}
 		n, _ := obfuscator.obfuscate(testFrame, obfsBuf, 0)
 
@@ -271,9 +260,8 @@ func BenchmarkDeobfs(b *testing.B) {
 		payloadCipher, _ := chacha20poly1305.New(key[:])
 
 		obfuscator := Obfuscator{
-			payloadCipher: nil,
+			payloadCipher: payloadCipher,
 			sessionKey:    key,
-			maxOverhead:   payloadCipher.Overhead(),
 		}
 
 		n, _ := obfuscator.obfuscate(testFrame, obfsBuf, 0)

--- a/internal/multiplex/session.go
+++ b/internal/multiplex/session.go
@@ -108,7 +108,7 @@ func MakeSession(id uint32, config SessionConfig) *Session {
 		sesh.InactivityTimeout = defaultInactivityTimeout
 	}
 
-	sesh.maxStreamUnitWrite = sesh.MsgOnWireSizeLimit - frameHeaderLength - sesh.maxOverhead
+	sesh.maxStreamUnitWrite = sesh.MsgOnWireSizeLimit - frameHeaderLength - maxExtraLen
 	sesh.streamSendBufferSize = sesh.MsgOnWireSizeLimit
 	sesh.connReceiveBufferSize = 20480 // for backwards compatibility
 


### PR DESCRIPTION
Xue et al. pointed out the problem of encapsulated TLS handshakes in [Fingerprinting Obfuscated Proxy Traffic
with Encapsulated TLS Handshakes](https://www.usenix.org/system/files/usenixsecurity24-xue-fingerprinting.pdf), whereby censors can look at the size and direction of the first few TCP packets to detect whether a TLS-in-TLS handshake is happening, indicating proxied TLS traffic. We pad the first few frames on a stream opening (up to 239 bytes) to mitigate this.

> Yet, we show that simple random padding schemes
drawing padding sizes from limited ranges (e.g., vmess: [0,
63]), while increasing the challenge, doesn’t render detec-
tion infeasible (TPR: 0.859 → 0.687 for vmess-ws-tls after
padding).